### PR TITLE
Node 8 and 10 not supported

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 8, 10, 12, 14, 16, 18 ]
+        node: [ 14, 16, 18 ]
     name: Node ${{ matrix.node }} sample
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Updating workflow to only run on Node 14, 16, 18 (8 and 10 aren't supported)